### PR TITLE
[FIX] 닉네임 중복 체크 기능 구현

### DIFF
--- a/src/main/java/com/drumtong/backend/api/member/repository/MemberRepository.java
+++ b/src/main/java/com/drumtong/backend/api/member/repository/MemberRepository.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByEmail(String email);
+    Optional<Member> findByNickname(String nickname);
 }

--- a/src/main/java/com/drumtong/backend/api/member/service/MemberService.java
+++ b/src/main/java/com/drumtong/backend/api/member/service/MemberService.java
@@ -46,6 +46,11 @@ public class MemberService {
             throw new BadRequestException(ErrorStatus.MISSING_EMAIL_VERIFICATION_EXCEPTION.getMessage());
         }
 
+        // 닉네임 중복 체크
+        if (memberRepository.findByNickname(memberRegisterRequestDTO.getNickname()).isPresent()) {
+            throw new BadRequestException(ErrorStatus.ALREADY_REGISTER_NICKNAME_EXCPETION.getMessage());
+        }
+
         // Member 엔티티 생성
         Member member = Member.builder()
                 .email(memberRegisterRequestDTO.getEmail())

--- a/src/main/java/com/drumtong/backend/common/response/ErrorStatus.java
+++ b/src/main/java/com/drumtong/backend/common/response/ErrorStatus.java
@@ -14,12 +14,12 @@ public enum ErrorStatus {
      */
     VALIDATION_REQUEST_MISSING_EXCEPTION(HttpStatus.BAD_REQUEST, "요청 값이 입력되지 않았습니다."),
     ALREADY_REGISTER_EMAIL_EXCPETION(HttpStatus.BAD_REQUEST, "이미 가입된 이메일 입니다."),
-    ALREADY_REGISTER_NICKNAME_EXCPETION(HttpStatus.BAD_REQUEST, "이미 등록된 이메일 입니다."),
     WRONG_EMAIL_VERIFICATION_CODE_EXCEPTION(HttpStatus.BAD_REQUEST,"이메일 인증코드가 올바르지 않습니다."),
     VALIDATION_EMAIL_FORMAT_EXCEPTION(HttpStatus.BAD_REQUEST,"올바른 이메일 형식이 아닙니다."),
     MISSING_EMAIL_VERIFICATION_EXCEPTION(HttpStatus.BAD_REQUEST,"이메일 인증을 진행해주세요."),
     WRONG_PASSWORD_EXCEPTION(HttpStatus.BAD_REQUEST,"아이디 또는 비밀번호가 일치하지 않습니다."),
     INVALID_PASSWORD_RESET_CODE_EXCEPTION(HttpStatus.BAD_REQUEST,"유효하지 않은 비밀번호 초기화 인증코드 입니다."),
+    ALREADY_REGISTER_NICKNAME_EXCPETION(HttpStatus.BAD_REQUEST, "이미 등록된 닉네임 입니다."),
 
     /**
      * 401 UNAUTHORIZED


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #15 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 회원가입 시 중복 체크 기능을 수행하도록 기능 구현하였습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 회원탈퇴 기능은 그룹, 캘린더 구현 및 연동 작업이 끝나면 마지막에 작업하겠습니다.